### PR TITLE
Archivo Roman.sql errata corregida en la tabla zona

### DIFF
--- a/Roman.sql
+++ b/Roman.sql
@@ -123,7 +123,7 @@ CREATE TABLE `zona` (
   `numerobarcos` int(11) NOT NULL,
   `profundidad` float NOT NULL,
   `ancho` float NOT NULL,
-  PRIMARI KEY  (`letra`)
+  PRIMARY KEY  (`letra`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
 
 -- 


### PR DESCRIPTION
En la creación de la tabla zona, la instrucción Primary Key está escrita erróneamente como Primari.
En la creación de la tabla embarcación está escrito Create Tabla en español en vez de como corresponde la instrucción que sería table. escrito en inglés

 